### PR TITLE
fix: test and miniscript

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1645,12 +1645,8 @@ add_test(NAME test_base64       COMMAND ${PYTHON_BIN} test/test_base64.py
                                 WORKING_DIRECTORY ${PY_TEST_DIR})
 add_test(NAME test_bech32       COMMAND ${PYTHON_BIN} test/test_bech32.py
                                 WORKING_DIRECTORY ${PY_TEST_DIR})
-if(MSVC)
-# skip bip32 test (for error)
-else()
 add_test(NAME test_bip32        COMMAND ${PYTHON_BIN} test/test_bip32.py
                                 WORKING_DIRECTORY ${PY_TEST_DIR})
-endif()
 add_test(NAME test_bip38        COMMAND ${PYTHON_BIN} test/test_bip38.py
                                 WORKING_DIRECTORY ${PY_TEST_DIR})
 add_test(NAME test_bip39        COMMAND ${PYTHON_BIN} test/test_bip39.py
@@ -1683,10 +1679,8 @@ add_test(NAME test_wordlist     COMMAND ${PYTHON_BIN} test/test_wordlist.py
                                 WORKING_DIRECTORY ${PY_TEST_DIR})
 add_test(NAME test_descriptor   COMMAND ${PYTHON_BIN} test/test_descriptor.py
                                 WORKING_DIRECTORY ${PY_TEST_DIR})
-if(NOT PY_TEST_IGNORE)
 add_test(NAME test_transaction  COMMAND ${PYTHON_BIN} test/test_transaction.py
                                 WORKING_DIRECTORY ${PY_TEST_DIR})
-endif(NOT PY_TEST_IGNORE)
 
 if(ENABLE_ELEMENTS)
 add_test(NAME test_elements           COMMAND ${PYTHON_BIN} test/test_elements.py
@@ -1695,12 +1689,10 @@ add_test(NAME test_pset               COMMAND ${PYTHON_BIN} test/test_pset.py
                                       WORKING_DIRECTORY ${PY_TEST_DIR})
 add_test(NAME test_confidential_addr  COMMAND ${PYTHON_BIN} test/test_confidential_addr.py
                                       WORKING_DIRECTORY ${PY_TEST_DIR})
-if(NOT PY_TEST_IGNORE)
 add_test(NAME test_pegin              COMMAND ${PYTHON_BIN} test/test_pegin.py
                                       WORKING_DIRECTORY ${PY_TEST_DIR})
 add_test(NAME test_pegout             COMMAND ${PYTHON_BIN} test/test_pegout.py
                                       WORKING_DIRECTORY ${PY_TEST_DIR})
-endif(NOT PY_TEST_IGNORE)
 endif() # ENABLE_ELEMENTS
 endif() # ${ENABLE_SHARED} AND ${INSTALL_WALLYCORE}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1400,6 +1400,9 @@ add_test(
 ####################
 # test for C(secp256k1)
 ####################
+if(ENABLE_SHARED)
+# do nothing
+else() # not ENABLE_SHARED
 if(ENABLE_SECP256K1_TEST AND ${ENABLE_SECP256K1_TEST})
 set(TEST_SECP256K1_NAME ctest_secp256k1)
 set(TEST_SECP256K1_FILES
@@ -1407,7 +1410,6 @@ set(TEST_SECP256K1_FILES
     ${CONFIG_HEADER_DIRECTORY}/libsecp256k1-config.h
     src/secp256k1/include/secp256k1.h
     src/secp256k1/include/secp256k1_recovery.h
-    ${ECMULT_STATIC_CONTEXT_H}
 )
 add_executable(${TEST_SECP256K1_NAME} ${TEST_SECP256K1_FILES})
 target_compile_options(${TEST_SECP256K1_NAME}
@@ -1438,13 +1440,61 @@ target_link_libraries(${TEST_SECP256K1_NAME}
   PRIVATE $<IF:$<OR:$<PLATFORM_ID:Darwin>,$<PLATFORM_ID:Windows>>,,rt>
   PRIVATE $<$<BOOL:$<C_COMPILER_ID:GCC>>:-static-libgcc>
   PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:pthread>
+  PRIVATE
+    ${TEST_WALY_LIB}
 )
 add_test(
   NAME ${TEST_SECP256K1_NAME}
   COMMAND $<TARGET_FILE:${TEST_SECP256K1_NAME}>
   WORKING_DIRECTORY ${WALLY_OBJ_BINARY_DIR}
 )
+
+set(TEST_SECP256K1_ENHAUSTIVE_NAME ctest_secp256k1_exhaustive)
+set(TEST_SECP256K1_ENHAUSTIVE_FILES
+    src/secp256k1/src/tests_exhaustive.c
+    ${CONFIG_HEADER_DIRECTORY}/libsecp256k1-config.h
+    src/secp256k1/include/secp256k1.h
+    src/secp256k1/include/secp256k1_recovery.h
+)
+add_executable(${TEST_SECP256K1_ENHAUSTIVE_NAME} ${TEST_SECP256K1_ENHAUSTIVE_FILES})
+target_compile_options(${TEST_SECP256K1_ENHAUSTIVE_NAME}
+  PRIVATE
+    $<IF:$<C_COMPILER_ID:MSVC>,
+      /source-charset:utf-8 /wd4251,
+      -Wall -Wextra -Wno-unused-function
+      ${PROFILE_ARCS_OPT} ${TEST_COVERAGE_OPT}
+    >
+)
+target_compile_definitions(${TEST_SECP256K1_ENHAUSTIVE_NAME}
+  PRIVATE
+    SECP256K1_BUILD
+    HAVE_CONFIG_H
+)
+target_include_directories(${TEST_SECP256K1_ENHAUSTIVE_NAME}
+  PRIVATE
+    ${CONFIG_HEADER_DIRECTORY}
+    .
+    src/secp256k1
+    src/secp256k1/include
+    src/secp256k1/src
+)
+target_link_directories(${TEST_SECP256K1_ENHAUSTIVE_NAME}  PRIVATE ./ )
+target_link_libraries(${TEST_SECP256K1_ENHAUSTIVE_NAME}
+  PRIVATE $<$<BOOL:$<C_COMPILER_ID:MSVC>>:winmm.lib>
+  PRIVATE $<$<BOOL:$<C_COMPILER_ID:MSVC>>:ws2_32.lib>
+  PRIVATE $<IF:$<OR:$<PLATFORM_ID:Darwin>,$<PLATFORM_ID:Windows>>,,rt>
+  PRIVATE $<$<BOOL:$<C_COMPILER_ID:GCC>>:-static-libgcc>
+  PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:pthread>
+  PRIVATE
+    ${TEST_WALY_LIB}
+)
+add_test(
+  NAME ${TEST_SECP256K1_ENHAUSTIVE_NAME}
+  COMMAND $<TARGET_FILE:${TEST_SECP256K1_ENHAUSTIVE_NAME}>
+  WORKING_DIRECTORY ${WALLY_OBJ_BINARY_DIR}
+)
 endif(ENABLE_SECP256K1_TEST AND ${ENABLE_SECP256K1_TEST})
+endif() # not ENABLE_SHARED
 
 ####################
 # test for C(Elements)

--- a/include/wally_bip32.h
+++ b/include/wally_bip32.h
@@ -298,7 +298,7 @@ WALLY_CORE_API int bip32_key_from_parent_path_alloc(
  * :param flags: ``BIP32_FLAG_`` Flags indicating the type of derivation wanted.
  * :param output: Destination for the resulting child extended key.
  */
-int bip32_key_from_parent_path_str(
+WALLY_CORE_API int bip32_key_from_parent_path_str(
     const struct ext_key *hdkey,
     const char *path_str,
     uint32_t child_num,
@@ -310,7 +310,7 @@ int bip32_key_from_parent_path_str(
  *
  * See `bip32_key_from_parent_path_str`.
  */
-int bip32_key_from_parent_path_str_n(
+WALLY_CORE_API int bip32_key_from_parent_path_str_n(
     const struct ext_key *hdkey,
     const char *path_str,
     size_t path_str_len,
@@ -323,7 +323,7 @@ int bip32_key_from_parent_path_str_n(
  * As per `bip32_key_from_parent_path_str`, but allocates the key.
  * .. note:: The returned key should be freed with `bip32_key_free`.
  */
-int bip32_key_from_parent_path_str_alloc(
+WALLY_CORE_API int bip32_key_from_parent_path_str_alloc(
     const struct ext_key *hdkey,
     const char *path_str,
     uint32_t child_num,
@@ -334,7 +334,7 @@ int bip32_key_from_parent_path_str_alloc(
  * As per `bip32_key_from_parent_path_str_n`, but allocates the key.
  * .. note:: The returned key should be freed with `bip32_key_free`.
  */
-int bip32_key_from_parent_path_str_n_alloc(
+WALLY_CORE_API int bip32_key_from_parent_path_str_n_alloc(
     const struct ext_key *hdkey,
     const char *path_str,
     size_t path_str_len,

--- a/src/ctest/test_descriptor.c
+++ b/src/ctest/test_descriptor.c
@@ -159,6 +159,7 @@ struct wally_miniscript_ref_test g_miniscript_ref_test_table[] = {
 struct wally_miniscript_ref_test g_miniscript_err_test_table[] = {
     {"thresh(3,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),sc:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))", ""},
     {"thresh(0,c:pk_k(03d30199d74fb5a22d47b6e054e2f378cedacffcb89904a61d75d0dbd407143e65),sc:pk_k(03fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556))", ""},
+    {"thresh(3,pk(038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048),s:pk(03a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7),s:pk(03b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284),sln:older(12960))", ""},
 };
 
 struct wally_miniscript_test g_miniscript_test_table[] = {
@@ -182,13 +183,6 @@ struct wally_miniscript_test g_miniscript_test_table[] = {
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ad2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac736402a032b268",
         "and_v(vc:pk_k(key_user),or_d(c:pk_k(key_service),older(12960)))",
         "00201264946c666958d9522f63dcdcfc85941bdd5b9308b1e6c68696857506f6cced"
-    },
-    {
-        "miniscript - A 3-of-3 that turns into a 2-of-3 after 90 days",
-        "thresh(3,c:pk_k(038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048),sc:pk_k(03a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7),sc:pk_k(03b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284),sdv:older(12960))",
-        "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac7c2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac937c2103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac937c766302a032b26968935387",
-        "thresh(3,c:pk_k(key_1),sc:pk_k(key_2),sc:pk_k(key_3),sdv:older(12960))",
-        "0020ab3551bec623130218a9ca5da0e3adb82b8569f91355a483653a49f2a2dd6e70"
     },
     {
         "miniscript - The BOLT #3 to_local policy",
@@ -231,13 +225,6 @@ struct wally_miniscript_test g_miniscript_test_table[] = {
         "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ad2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac736402a032b268",
         "and_v(v:pk(key_user),or_d(pk(key_service),older(12960)))",
         "00201264946c666958d9522f63dcdcfc85941bdd5b9308b1e6c68696857506f6cced"
-    },
-    {
-        "miniscript(2) - A 3-of-3 that turns into a 2-of-3 after 90 days",
-        "thresh(3,pk(038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048),s:pk(03a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7),s:pk(03b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284),sdv:older(12960))",
-        "21038bc7431d9285a064b0328b6333f3a20b86664437b6de8f4e26e6bbdee258f048ac7c2103a22745365f673e658f0d25eb0afa9aaece858c6a48dfe37a67210c2e23da8ce7ac937c2103b428da420cd337c7208ed42c5331ebb407bb59ffbe3dc27936a227c619804284ac937c766302a032b26968935387",
-        "thresh(3,pk(key_1),s:pk(key_2),s:pk(key_3),sdv:older(12960))",
-        "0020ab3551bec623130218a9ca5da0e3adb82b8569f91355a483653a49f2a2dd6e70"
     },
     {
         "miniscript(2) - The BOLT #3 to_local policy",
@@ -444,12 +431,6 @@ struct wally_descriptor_test g_descriptor_test_table[] = {
         "00201264946c666958d9522f63dcdcfc85941bdd5b9308b1e6c68696857506f6cced",
         NULL,
         "7sxzh689"
-    },{
-        "descriptor - A 3-of-3 that turns into a 2-of-3 after 90 days",
-        "wsh(thresh(3,c:pk_k(key_1),sc:pk_k(key_2),sc:pk_k(key_3),sdv:older(12960)))",
-        "0020ab3551bec623130218a9ca5da0e3adb82b8569f91355a483653a49f2a2dd6e70",
-        NULL,
-        "vvsamau0"
     },{
         "descriptor - The BOLT #3 to_local policy",
         "wsh(andor(c:pk_k(key_local),older(1008),c:pk_k(key_revocation)))",
@@ -686,12 +667,6 @@ struct wally_descriptor_address_test g_descriptor_address_test_table[] = {
         0,
         WALLY_NETWORK_BITCOIN_MAINNET,
         "bc1qzfjfgmrxd9vdj530v0wdely9jsda6kunpzc7d35xj6zh2phkenkstn6ur7"
-    },{
-        "address - A 3-of-3 that turns into a 2-of-3 after 90 days",
-        "wsh(thresh(3,c:pk_k(key_1),sc:pk_k(key_2),sc:pk_k(key_3),sdv:older(12960)))",
-        0,
-        WALLY_NETWORK_BITCOIN_MAINNET,
-        "bc1q4v64r0kxyvfsyx9fefw6pcadhq4c260ezd26fqm98fyl9gkadecqy9uufs"
     },{
         "address - The BOLT #3 to_local policy",
         "wsh(andor(c:pk_k(key_local),older(1008),c:pk_k(key_revocation)))",

--- a/src/descriptor.c
+++ b/src/descriptor.c
@@ -1023,7 +1023,7 @@ static int verify_miniscript_wrapper_d(struct miniscript_node_t *node, struct mi
     node->type_properties &= ~need_type;
     node->type_properties |= MINISCRIPT_TYPE_B;
     node->type_properties &= MINISCRIPT_TYPE_MASK | MINISCRIPT_PROPERTY_M | MINISCRIPT_PROPERTY_S;
-    node->type_properties |= MINISCRIPT_PROPERTY_N | MINISCRIPT_PROPERTY_U |
+    node->type_properties |= MINISCRIPT_PROPERTY_N |
                              MINISCRIPT_PROPERTY_D | MINISCRIPT_PROPERTY_X |
                              MINISCRIPT_PROPERTY_G | MINISCRIPT_PROPERTY_H |
                              MINISCRIPT_PROPERTY_I | MINISCRIPT_PROPERTY_J |

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -78,58 +78,58 @@ c_uint_p = POINTER(c_uint)
 
 class wally_tx_witness_item(Structure):
     _fields_ = [('witness', c_void_p),
-                ('len', c_ulong)]
+                ('len', c_size_t)]
 
 class wally_tx_witness_stack(Structure):
     _fields_ = [('items', POINTER(wally_tx_witness_item)),
-                ('num_items', c_ulong),
-                ('items_allocation_len', c_ulong)]
+                ('num_items', c_size_t),
+                ('items_allocation_len', c_size_t)]
 
 class wally_tx_input(Structure):
     _fields_ = [('txhash', c_ubyte * 32),
                 ('index', c_uint),
                 ('sequence', c_uint),
                 ('script', c_void_p),
-                ('script_len', c_ulong),
+                ('script_len', c_size_t),
                 ('witness',  POINTER(wally_tx_witness_stack)),
                 ('features', c_ubyte),
                 ('blinding_nonce', c_ubyte * 32),
                 ('entropy', c_ubyte * 32),
                 ('issuance_amount', c_void_p),
-                ('issuance_amount_len', c_ulong),
+                ('issuance_amount_len', c_size_t),
                 ('inflation_keys', c_void_p),
-                ('inflation_keys_len', c_ulong),
+                ('inflation_keys_len', c_size_t),
                 ('issuance_amount_rangeproof', c_void_p),
-                ('issuance_amount_rangeproof_len', c_ulong),
+                ('issuance_amount_rangeproof_len', c_size_t),
                 ('inflation_keys_rangeproof', c_void_p),
-                ('inflation_keys_rangeproof_len', c_ulong),
+                ('inflation_keys_rangeproof_len', c_size_t),
                 ('pegin_witness', POINTER(wally_tx_witness_stack))]
 
 class wally_tx_output(Structure):
     _fields_ = [('satoshi', c_uint64),
                 ('script', c_void_p),
-                ('script_len', c_ulong),
+                ('script_len', c_size_t),
                 ('features', c_ubyte),
                 ('asset', c_void_p),
-                ('asset_len', c_ulong),
+                ('asset_len', c_size_t),
                 ('value', c_void_p),
-                ('value_len', c_ulong),
+                ('value_len', c_size_t),
                 ('nonce', c_void_p),
-                ('nonce_len', c_ulong),
+                ('nonce_len', c_size_t),
                 ('surjectionproof', c_void_p),
-                ('surjectionproof_len', c_ulong),
+                ('surjectionproof_len', c_size_t),
                 ('rangeproof', c_void_p),
-                ('rangeproof_len', c_ulong)]
+                ('rangeproof_len', c_size_t)]
 
 class wally_tx(Structure):
-    _fields_ = [('version', c_uint),
-                ('locktime', c_uint),
+    _fields_ = [('version', c_uint32),
+                ('locktime', c_uint32),
                 ('inputs', POINTER(wally_tx_input)),
-                ('num_inputs', c_ulong),
-                ('inputs_allocation_len', c_ulong),
+                ('num_inputs', c_size_t),
+                ('inputs_allocation_len', c_size_t),
                 ('outputs', POINTER(wally_tx_output)),
-                ('num_outputs', c_ulong),
-                ('outputs_allocation_len', c_ulong),]
+                ('num_outputs', c_size_t),
+                ('outputs_allocation_len', c_size_t),]
 
 class wally_map_item(Structure):
     _fields_ = [('key', c_void_p),


### PR DESCRIPTION
## Proposal

- fix: miniscript: the 'd:' wrapper must not be 'u'
  - merge
- fix: for windows
  - add WALLY_CORE_API
  - change c_ulong to c_size_t on python's test util.py
- test: ctest for windows
- test: fix secp256k1 for static only
  - because not defined dllexport