### PR TITLE
🔨 build: Update CXX standard to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,7 +557,7 @@ add_custom_command(OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/nodejs_wrap.cc
 )
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 add_library(${NODE_LIBRARY_NAME} SHARED)
 target_sources(${NODE_LIBRARY_NAME}
   PRIVATE


### PR DESCRIPTION
## What?

Bump CXX standard to c++ 14 for libwally.

## Why?

As of right now, cfd-dlc-js builds perfectly fine on node v14. However, when attempting to build node.js projects with cfd-dlc-js on node v16, the compilation fails with a very similar error message to the one described here: 
https://github.com/nodejs/node/issues/38367
```
 error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
            !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                ~~~~~^~~~~~~~~~~
                                     remove_cv
```

Digging deeper, I discovered that if I set CXX version of libwally (which is a dependency of cfd-dlc-js) to 14, then everything builds successfully on nodejs v16.

